### PR TITLE
Add Creative Commons attribution for Wikipedia content

### DIFF
--- a/marbles/core/tests/test_marbles.py
+++ b/marbles/core/tests/test_marbles.py
@@ -51,6 +51,12 @@ class OddArgumentOrderTestCaseMixin(object):
 # member existence don't get confused, we enforce that the marbles
 # TestCase subclasses are earlier in the method resolution order than
 # unittest.TestCase.
+
+# This test case uses material from the Wikipedia article
+# https://en.wikipedia.org/wiki/Marble_(toy) which is
+# released under the Creative Commons Attribution-Share-Alike
+# License 3.0 https://creativecommons.org/licenses/by-sa/3.0
+
 @unittest.skip('This is the TestCase being tested')
 class ExampleTestCaseMixin(
         ReversingTestCaseMixin,


### PR DESCRIPTION
I used the example notice [here](https://en.wikipedia.org/wiki/Wikipedia:Reusing_Wikipedia_content#Example_notice)

Closes #12 