### PR TITLE
Include bash prompt in all failure output examples in Sphinx docs

### DIFF
--- a/docs/examples/getting_started.txt
+++ b/docs/examples/getting_started.txt
@@ -1,4 +1,4 @@
-python -m marbles docs/examples/getting_started.py
+$ python -m marbles docs/examples/getting_started.py
 F
 ======================================================================
 FAIL: test_create_resource (docs.examples.getting_started.ResponseTestCase)


### PR DESCRIPTION
Docs at jane.local:6969 until they're not