### PR TITLE
Forward environment variables to subprocess test runs

### DIFF
--- a/marbles/core/tests/test_main.py
+++ b/marbles/core/tests/test_main.py
@@ -79,10 +79,10 @@ class CommandRunningTestCase(unittest.TestCase):
                 pth.flush()
 
             coverage_config = os.path.join(core_dir, '.coveragerc')
-            env = {'COVERAGE_PROCESS_START': coverage_config}
+            env = {**os.environ, **{'COVERAGE_PROCESS_START': coverage_config}}
             to_remove = pth.name
         else:
-            env = {}
+            env = None
             to_remove = None
         try:
             proc = subprocess.run(

--- a/marbles/core/tests/test_main.py
+++ b/marbles/core/tests/test_main.py
@@ -79,7 +79,7 @@ class CommandRunningTestCase(unittest.TestCase):
                 pth.flush()
 
             coverage_config = os.path.join(core_dir, '.coveragerc')
-            env = {**os.environ, **{'COVERAGE_PROCESS_START': coverage_config}}
+            env = {'COVERAGE_PROCESS_START': coverage_config, **os.environ}
             to_remove = pth.name
         else:
             env = None


### PR DESCRIPTION
One of the things we do to get coverage working with tests that we shell out to run is to forward the `COVERAGE_PROCESS_START` environment variable to `subprocess.run()`. But this is the _only_ environment variable we provide, meaning that the new process runs with only this environment variable set. If we're not running tests under coverage, we pass an empty dict to `subprocess.run()`, meaning the new process runs with _no_ environment variables set.

This PR changes how we shell out to run tests to forward the current process's environment to the new environment, with an additional `COVERAGE_PROCESS_START` variable if we're running tests under coverage.

Somewhere, something must be relying on an environment variable to find sysctl? I'm not sure what or what environment variable(s) they're relying on :/

Closes #58 