### PR TITLE
Turn off codecov PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,4 +5,5 @@ coverage:
         target: auto
         threshold: null
         base: auto 
-  comment: off
+
+comment: false


### PR DESCRIPTION
Looking at [the docs](https://docs.codecov.io/v4.3.6/docs/codecov-yaml#section-default-yaml), I think comments are configured in their own section of the config. This change should turn PR comments off.

I validated that this is a working config:
```
(marbles-rOKSo-69) marbles (codecov-config) $ curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "comment": false, 
  "coverage": {
    "status": {
      "project": {
        "default": {
          "base": "auto", 
          "threshold": null, 
          "target": "auto"
        }
      }
    }
  }
}
```

And that our existing config isn't valid:
```
(marbles-rOKSo-69) marbles (master) $ curl --data-binary @.codecov.yml https://codecov.io/validate
Invalid value {'status': {'project': {'default': {'base': 'auto', 'threshold': None, 'target': 'auto'}}}, 'comment': False} (dict): additional properties: ['comment'] (at coverage)
```