### PR TITLE
Format multiline locals by indenting all lines uniformly #92

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`92` Format multiline locals better
+* :feature:`92` Improve indentation of multiline locals
 * :support:`90` Added support for python 3.7
 * :support:`88` Document how to install with conda
 * :release:`0.9.5 <2018-06-24>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`92` Format multiline locals better
 * :support:`90` Added support for python 3.7
 * :support:`88` Document how to install with conda
 * :release:`0.9.5 <2018-06-24>`

--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -339,8 +339,7 @@ Source ({filename}):
 
     @classmethod
     def _format_locals(cls, locals_):
-        return '\n'.join(cls._format_local(k, v)
-                         for k, v in locals_.items())
+        return '\n'.join(cls._format_local(k, v) for k, v in locals_.items())
 
     @staticmethod
     def _find_assert_stmt(filename, linenumber, leading=1, following=2,

--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -329,8 +329,18 @@ Source ({filename}):
             note=self.note, locals=local_string, filename=self.filename)
 
     @classmethod
+    def _format_one_local(cls, name, value):
+        value_str = repr(value)
+        if '\n' in value_str:
+            value_str = textwrap.indent(value_str, '\t\t')
+            return '\t{0} =\n{1}'.format(name, value_str)
+        else:
+            return '\t{0} = {1}'.format(name, value_str)
+
+    @classmethod
     def _format_locals(cls, locals_):
-        return '\n'.join('\t{0}={1}'.format(k, v) for k, v in locals_.items())
+        return '\n'.join(cls._format_one_local(k, v)
+                         for k, v in locals_.items())
 
     @staticmethod
     def _find_assert_stmt(filename, linenumber, leading=1, following=2,

--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -329,7 +329,7 @@ Source ({filename}):
             note=self.note, locals=local_string, filename=self.filename)
 
     @classmethod
-    def _format_one_local(cls, name, value):
+    def _format_local(cls, name, value):
         value_str = repr(value)
         if '\n' in value_str:
             value_str = textwrap.indent(value_str, '\t\t')
@@ -339,7 +339,7 @@ Source ({filename}):
 
     @classmethod
     def _format_locals(cls, locals_):
-        return '\n'.join(cls._format_one_local(k, v)
+        return '\n'.join(cls._format_local(k, v)
                          for k, v in locals_.items())
 
     @staticmethod

--- a/marbles/core/tests/test_marbles.py
+++ b/marbles/core/tests/test_marbles.py
@@ -210,6 +210,19 @@ unearthed in the excavation of an old privy in New Orleans.'''
         foo = 'bar'  # noqa: F841
         self.assertTrue(False, note='some note about {foo!r}')
 
+    def test_multiline_locals(self):
+        class Record(object):
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def __repr__(self):
+                return 'Record(\n{}\n)'.format('\n'.join(
+                    '  {key} = {value!r},'.format(key=key, value=value)
+                    for key, value in self.kwargs.items()
+                ))
+        foo = Record(a=1, b=2)  # noqa: F841
+        self.assertTrue(False, note='some note')
+
     def test_string_equality(self):
         s = ''
         self.assertEqual(s, s, note='some note')
@@ -480,6 +493,14 @@ class TestContextualAssertionError(MarblesTestCase):
         e = ar.exception
         self.assertEqual(e.note.strip(), "some note about 'bar'")
 
+    def test_verify_multiline_locals(self):
+        '''Are locals with multiline reprs formatted correctly?'''
+        with self.assertRaises(ContextualAssertionError) as ar:
+            self.case.test_multiline_locals()
+        e = ar.exception
+        self.assertIn("\n\t\t  a = 1,\n",
+                      e._format_locals(e.public_test_locals))
+
     def test_assert_raises_without_msg(self):
         '''Do we capture annotations properly for assertRaises?'''
         with self.assertRaises(ContextualAssertionError) as ar:
@@ -506,7 +527,7 @@ class TestContextualAssertionError(MarblesTestCase):
         self.assertEqual(e.filename, os.path.abspath(__file__))
         # This isn't great because I have to change it every time I
         # add/remove imports but oh well
-        self.assertEqual(e.linenumber, 83)
+        self.assertEqual(e.linenumber, 84)
 
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_locals()
@@ -515,11 +536,11 @@ class TestContextualAssertionError(MarblesTestCase):
         self.assertEqual(e.filename, os.path.abspath(__file__))
         # This isn't great because I have to change it every time I
         # add/remove imports but oh well
-        self.assertEqual(e.linenumber, 211)
+        self.assertEqual(e.linenumber, 212)
 
     def test_assert_stmt_indicates_line(self):
         '''Does e.assert_stmt indicate the line from the source code?'''
-        test_linenumber = 83
+        test_linenumber = 84
         test_filename = os.path.abspath(__file__)
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_failure()
@@ -538,16 +559,16 @@ class TestContextualAssertionError(MarblesTestCase):
 
     def test_assert_stmt_surrounding_lines(self):
         '''Does _find_assert_stmt read surrounding lines from the file?'''
-        test_linenumber = 75
+        test_linenumber = 84
         test_filename = os.path.abspath(__file__)
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_failure()
         e = ar.exception
         lines = e._find_assert_stmt(test_filename, test_linenumber)[0]
-        self.assertEqual(len(lines), 7)
+        self.assertEqual(len(lines), 3)
         more_lines = e._find_assert_stmt(
             test_filename, test_linenumber, 2, 5)[0]
-        self.assertEqual(len(more_lines), 11)
+        self.assertEqual(len(more_lines), 7)
 
     def test_note_wrapping(self):
         '''Do we wrap the note properly?'''

--- a/marbles/core/tests/test_marbles.py
+++ b/marbles/core/tests/test_marbles.py
@@ -527,7 +527,7 @@ class TestContextualAssertionError(MarblesTestCase):
         self.assertEqual(e.filename, os.path.abspath(__file__))
         # This isn't great because I have to change it every time I
         # add/remove imports but oh well
-        self.assertEqual(e.linenumber, 84)
+        self.assertEqual(e.linenumber, 83)
 
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_locals()
@@ -540,7 +540,7 @@ class TestContextualAssertionError(MarblesTestCase):
 
     def test_assert_stmt_indicates_line(self):
         '''Does e.assert_stmt indicate the line from the source code?'''
-        test_linenumber = 84
+        test_linenumber = 83
         test_filename = os.path.abspath(__file__)
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_failure()
@@ -559,7 +559,7 @@ class TestContextualAssertionError(MarblesTestCase):
 
     def test_assert_stmt_surrounding_lines(self):
         '''Does _find_assert_stmt read surrounding lines from the file?'''
-        test_linenumber = 84
+        test_linenumber = 83
         test_filename = os.path.abspath(__file__)
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_failure()

--- a/marbles/core/tests/test_marbles.py
+++ b/marbles/core/tests/test_marbles.py
@@ -493,8 +493,8 @@ class TestContextualAssertionError(MarblesTestCase):
         e = ar.exception
         self.assertEqual(e.note.strip(), "some note about 'bar'")
 
-    def test_verify_multiline_locals(self):
-        '''Are locals with multiline reprs formatted correctly?'''
+    def test_multiline_locals_indentation(self):
+        '''Are locals with multiline reprs indented correctly?'''
         with self.assertRaises(ContextualAssertionError) as ar:
             self.case.test_multiline_locals()
         e = ar.exception

--- a/marbles/core/tests/test_marbles.py
+++ b/marbles/core/tests/test_marbles.py
@@ -536,7 +536,7 @@ class TestContextualAssertionError(MarblesTestCase):
         self.assertEqual(e.filename, os.path.abspath(__file__))
         # This isn't great because I have to change it every time I
         # add/remove imports but oh well
-        self.assertEqual(e.linenumber, 212)
+        self.assertEqual(e.linenumber, 211)
 
     def test_assert_stmt_indicates_line(self):
         '''Does e.assert_stmt indicate the line from the source code?'''


### PR DESCRIPTION
Still needs tests, and probably needs to update some other tests' expected strings.