### PR TITLE
Made notes dedent before reformatting

### DIFF
--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -539,6 +539,9 @@ class TestCase(unittest.TestCase):
 
             note = kwargs.pop('note', None)
 
+            if note:
+                note = textwrap.dedent(note)
+
             with AnnotationContext(
                     self, attr, self._REQUIRED_KEYS, msg, note,
                     list(args) + list(rem_args), kwargs) as annotation:


### PR DESCRIPTION
Fixes #107 

Had to include the null check because `textwrap.dedent` throws with input `None` 