### PR TITLE
Truncate long local variable values with unittest utils

### DIFF
--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -339,7 +339,10 @@ Source ({filename}):
 
     @classmethod
     def _format_locals(cls, locals_):
-        return '\n'.join(cls._format_local(k, v) for k, v in locals_.items())
+        local_variable_names, local_variable_values = zip(*locals_.items())
+        shortened_local_variable_values = unittest.util._common_shorten_repr(*local_variable_values)
+        new_locals_items_representation = zip(local_variable_names, shortened_local_variable_values)
+        return '\n'.join(cls._format_local(k, v) for k, v in new_locals_items_representation)
 
     @staticmethod
     def _find_assert_stmt(filename, linenumber, leading=1, following=2,

--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -61,6 +61,7 @@ import re
 import sys
 import textwrap
 import unittest
+from unittest import util
 
 from . import log
 from . import _stack
@@ -330,18 +331,17 @@ Source ({filename}):
 
     @classmethod
     def _format_local(cls, name, value):
-        def truncate(s):
-            return unittest.util.safe_repr(s, short=True)
         value_str = repr(value)
         if '\n' in value_str:
             value_str_lines = value_str.split('\n')
-            value_str_lines = [truncate(line) for line in value_str_lines]
-            truncated_value_str = '\n'.join(value_str_lines)
-            value_str = textwrap.indent(truncated_value_str, '\t\t')
+            short_lines = [util.safe_repr(line, short=True)
+                           for line in value_str_lines]
+            short_value_str = '\n'.join(short_lines)
+            value_str = textwrap.indent(short_value_str, '\t\t')
             return '\t{0} =\n{1}'.format(name, value_str)
         else:
-            value_str = truncate(value_str)
-            return '\t{0} = {1}'.format(name, value_str)
+            short_value_str = util.safe_repr(value_str, short=True)
+            return '\t{0} = {1}'.format(name, short_value_str)
 
     @classmethod
     def _format_locals(cls, locals_):

--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -330,13 +330,18 @@ Source ({filename}):
 
     @classmethod
     def _format_local(cls, name, value):
+        def truncate(s):
+            return unittest.util.safe_repr(s, short=True)
         value_str = repr(value)
         if '\n' in value_str:
-            value_str = textwrap.indent(value_str, '\t\t')
+            value_str_lines = value_str.split('\n')
+            value_str_lines = [truncate(line) for line in value_str_lines]
+            truncated_value_str = '\n'.join(value_str_lines)
+            value_str = textwrap.indent(truncated_value_str, '\t\t')
             return '\t{0} =\n{1}'.format(name, value_str)
         else:
-            short_value_str = unittest.util.safe_repr(value_str, short=True)
-            return '\t{0} = {1}'.format(name, short_value_str)
+            value_str = truncate(value_str)
+            return '\t{0} = {1}'.format(name, value_str)
 
     @classmethod
     def _format_locals(cls, locals_):

--- a/marbles/core/marbles/core/marbles.py
+++ b/marbles/core/marbles/core/marbles.py
@@ -335,14 +335,12 @@ Source ({filename}):
             value_str = textwrap.indent(value_str, '\t\t')
             return '\t{0} =\n{1}'.format(name, value_str)
         else:
-            return '\t{0} = {1}'.format(name, value_str)
+            short_value_str = unittest.util.safe_repr(value_str, short=True)
+            return '\t{0} = {1}'.format(name, short_value_str)
 
     @classmethod
     def _format_locals(cls, locals_):
-        local_variable_names, local_variable_values = zip(*locals_.items())
-        shortened_local_variable_values = unittest.util._common_shorten_repr(*local_variable_values)
-        new_locals_items_representation = zip(local_variable_names, shortened_local_variable_values)
-        return '\n'.join(cls._format_local(k, v) for k, v in new_locals_items_representation)
+        return '\n'.join(cls._format_local(k, v) for k, v in locals_.items())
 
     @staticmethod
     def _find_assert_stmt(filename, linenumber, leading=1, following=2,


### PR DESCRIPTION
Addresses #75.

The issue suggests using something from [`unittest.util`](https://github.com/python/cpython/blob/master/Lib/unittest/util.py). This util has [`_common_shorten_repr`](https://github.com/python/cpython/blob/e8113f51a8bdf33188ee30a1c038a298329e7bfa/Lib/unittest/util.py#L24), which, given a dictionary, possibly truncates the values in it. We call this directly on the dictionary with local variables. Very open to that not being the optimal solution, but it should start the conversation.

## Example use

Make `test_shortened_values.py`, which is the example [`docs/examples/extra_locals.py`](docs/examples/extra_locals.py), slightly modified, so the file path becomes long:

```python
import os
import marbles.core


class FileTestCase(marbles.core.TestCase):

    def test_file_size(self):
        file_name = __file__ + __file__  # noqa: F841

        self.assertEqual(os.path.getsize(__file__), 0)


if __name__ == '__main__':
    marbles.core.main()
```

Now, running this, we get

```
» python -m marbles test_shortened_values.py
F
======================================================================
FAIL: test_file_size (test_shortened_values.FileTestCase)
----------------------------------------------------------------------
marbles.core.marbles.ContextualAssertionError: 269 != 0

Source (/Users/vegard/Documents/dev/marbles/test_shortened_values.py):
      9
 >   10 self.assertEqual(os.path.getsize(__file__), 0)
     11
Locals:
	file_name = "'/Use[54 chars]py/Users/vegard/Documents/dev/marbles/test_shortened_values.py'"


----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (failures=1)
```
Notice the `[54 chars]` in there. Is this somewhat in the right direction, @thejunglejane?

I have not added tests, yet, so would love some pointers as to how that might be done. (And I signed and sent a CLA.)