### PR TITLE
replace disallowed sphinx role 'file' in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Marbles also creates a setuptools command so if you are used to running
     python setup.py marbles
 
 You can go one step further and alias the command test to run marbles
-by adding the following to :file:`setup.cfg`:
+by adding the following to ``setup.cfg``:
 
 .. code-block:: bash
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`125` Fix long_description for PyPI
 * :release:`0.12.0 <2020-05-23>`
 * :support:`120` Upgrade to python 3.8
 * :support:`119` Upgrade to pandas 1.0


### PR DESCRIPTION
## Purpose
PyPI has started validating rST descriptions, and they don't allow Sphinx roles like `:file:`

## Approach
Replace the role with just monospace text.

